### PR TITLE
- fix: some environments don't have window object

### DIFF
--- a/packages/state/src/decorators/query.ts
+++ b/packages/state/src/decorators/query.ts
@@ -10,7 +10,7 @@ export type QueryOptions = {
 	skipAsync?: boolean
 }
 
-const url = new URL(window.location.href)
+const url = new URL(location.href)
 
 /**
  * A decorator for setting state values from url parameters


### PR DESCRIPTION
## Motivation

In chrome extension MV3 will be throw some env errors like: `window is not defined`.

Reason:
- In MV3, `window` object has moved to [Offscreen API](https://developer.chrome.com/docs/extensions/migrating/to-service-workers/#move-dom-and-window)
- globalThis.location still works

This PR can fix it.