### PR TITLE
fix: Error when StateController is added to element that is already connected

### DIFF
--- a/packages/state/src/state-controller.ts
+++ b/packages/state/src/state-controller.ts
@@ -17,8 +17,8 @@ export class StateController<T extends State>
 		private state: T,
 		cb?: callback,
 	) {
-		this.host.addController(this);
 		this.callback = cb ? cb : () => this.host.requestUpdate()
+		this.host.addController(this);
 	}
 
 	hostConnected(): void {


### PR DESCRIPTION
If a `StateController` is added to an element that is already connected to the DOM, then you'll get an error:

```
TypeError: this.callback is not a function
    at StateController.hostConnected
    at ReactiveControllerHost.addController
```

The callback needs to be initialised before adding the controller to the element. 

Great work on the project, by the way! Super simple yet does everything you need.