### PR TITLE
Support sessionStorage option

### DIFF
--- a/packages/state/Documentation.md
+++ b/packages/state/Documentation.md
@@ -106,6 +106,10 @@ The key to use for localStorage. Will take the name of the property if not set.
 
 A prefix to use for the the key (`_ls` if not set). An usual practice would be to override @storage and provide a default prefix for all `@storage` state values.
 
+`store`
+
+By default, `localStorage` is used as the backing store. Set to `'session'` to use `sessionStorage`, or optionally `'local'` to use `localStorage` (default).
+
 **Example**
 
 ```ts

--- a/packages/state/test/decorator.test.ts
+++ b/packages/state/test/decorator.test.ts
@@ -68,6 +68,17 @@ describe("decorator", () => {
 		expect(localStorage.getItem('_ls_aa')).toBe(2)
   });
 
+	it("sync @property({value}) with session storage", () => {
+		class S extends State {
+			@storage({key: 'aa', store: 'session'})
+			@property({value: 1}) a;
+		}
+		const s = new S()
+		expect(sessionStorage.getItem('_ls_aa')).toBe(1)
+		s.a = 2
+		expect(sessionStorage.getItem('_ls_aa')).toBe(2)
+  });
+
 	it("sync @query({value}) ", async () => {
 		class S extends State {
 			@query({parameter: 'aa'})


### PR DESCRIPTION
Optional parameter for `@storage` to use `sessionStorage`, and `localStorage` remains the default.