### PR TITLE
Allow @storage to have no prefix

### DIFF
--- a/packages/state/Documentation.md
+++ b/packages/state/Documentation.md
@@ -105,6 +105,7 @@ The key to use for localStorage. Will take the name of the property if not set.
 `prefix` 
 
 A prefix to use for the the key (`_ls` if not set). An usual practice would be to override @storage and provide a default prefix for all `@storage` state values.
+Set to `null` or `''` to remove the prefix.
 
 **Example**
 

--- a/packages/state/src/decorators/storage.ts
+++ b/packages/state/src/decorators/storage.ts
@@ -4,7 +4,7 @@ import { parse } from './parse.js';
 import { functionValue } from '../functionValue.js';
 export type StorageOptions = {
 	key?: string,
-	prefix?: string
+	prefix?: string | null,
 }
 
 const defaultOptions: StorageOptions = {

--- a/packages/state/src/decorators/storage.ts
+++ b/packages/state/src/decorators/storage.ts
@@ -53,7 +53,9 @@ export function storage(options?: StorageOptions) {
 		if (!descriptor) {
 			throw new Error('@local-storage decorator need to be called after @property')
 		}	
-		const key: string = `${options?.prefix || ''}_${options?.key || String(name)}`;
+		const key = options?.prefix
+			? `${options.prefix}_${options?.key || String(name)}`
+			: (options?.key || String(name));
 		const ctor = (proto).constructor as typeof State;
 		const definition = ctor.propertyMap.get(name);
 		const type = definition?.type

--- a/packages/state/test/decorator.test.ts
+++ b/packages/state/test/decorator.test.ts
@@ -68,6 +68,17 @@ describe("decorator", () => {
 		expect(localStorage.getItem('_ls_aa')).toBe(2)
   });
 
+	it("sync @property({value}) with local storage with no prefix", () => {
+		class S extends State {
+			@storage({key: 'aa', prefix: null })
+			@property({value: 1}) a;
+		}
+		const s = new S()
+		expect(localStorage.getItem('aa')).toBe(1)
+		s.a = 2
+		expect(localStorage.getItem('aa')).toBe(2)
+  });
+
 	it("sync @query({value}) ", async () => {
 		class S extends State {
 			@query({parameter: 'aa'})


### PR DESCRIPTION
Currently `@storage` will always have an `'_'` prefix even if the prefix option is set to an empty string. It is impossible to have no prefix.

This allows there to be truly no prefix if the `prefix` option is specified as empty.

`'ls_'` remains the default prefix.